### PR TITLE
PULL (Examples) Increase example iframe height

### DIFF
--- a/src/styles/doc.scss
+++ b/src/styles/doc.scss
@@ -119,6 +119,7 @@ Last Updated    3 October 2014
 
     .example iframe {
       border: none;
+      height: 500px;
       width: 100%;
     }
     .example .code {
@@ -145,7 +146,7 @@ Last Updated    3 October 2014
         color: white;
         font-weight: bold;
       }
-    
+
       .swatch__base,
       .swatch__selected,
       .swatch__transparent,
@@ -155,7 +156,7 @@ Last Updated    3 October 2014
 
         padding: 0.5em;
         margin: 0;
-        
+
         width: 33.333%;
         color: white;
         float: left;


### PR DESCRIPTION
Many of the pattern examples were difficult 
to read as it was like peering at them through
a letterbox. I've increased their iframe height
to 500px each. Most now display in their 
entirety, a few of the larger ones still need to 
scroll but they are more usable now.