### PR TITLE
DOCS (Breadcrumbs) Minor typographic changes

### DIFF
--- a/src/patterns/breadcrumbs/breadcrumbs.doc.hbs
+++ b/src/patterns/breadcrumbs/breadcrumbs.doc.hbs
@@ -10,7 +10,6 @@ examples:
 <h2>Usage</h2>
 
 <ul>
-	<li>Should not be used on the homepage or on longform pages.</li>
-    <li>Should be used at the top of all other content pages.</li>
-    <li>Should always sit below the navigation bar and above the page content.</li>
+	<li>Must not be used on the homepage or on <a href="../long-form/index.html">long-form content</a> pages.</li>
+    <li>Must be used at the top of content pages, sitting immediately beneath the <a href="../navigation-bar/index.html">navigation bar</a> and above the page content.</li>
 </ul>


### PR DESCRIPTION
Correct typo in "long-form content".
Add links to long-form content and navigation bar patterns.
Combine second and third bullet points to improve clarity.