### PR TITLE
MERGE (Example text banner) Fix URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,50 @@ This project adheres to [semantic versioning](http://semver.org/).
 Changes are grouped under the labels: `Added`, `Changed`, `Deprecated`, 
 `Removed`, `Fixed`, and `Security`.
 
+
+## v0.8.14
+
+Release date: Sunday 8 January 2017
+
+### Added
+
+* Add section number for "Update an existing install" (now section 3).
+* Add section 4 for troubleshooting, and add steps to resolve "Error: handlebars does not support render".
+
+### Fixed
+
+* Correct URL in text-banner on example pages to take users back to the examples homepage.
+
+
+
+
+---
+
+## v0.8.13
+
+Release date: Tuesday 20 December 2016
+
+### Added
+
+* Add navigation to Bootstrap components page.
+
+### Changed
+
+* Reorder (A-Z) and simplify navigation on Bootstrap components - advanced page.
+
+
+
+
+---
+
 ## v0.8.12
 
 Release date: Friday 16 December 2016
 
 ### Changed
 
-* Re-named 'Pattern-pages' to 'Patterns'.
-* Re-named 'Example-pages' to 'Examples'. 
+* Rename 'Pattern-pages' to 'Patterns'.
+* Rename 'Example-pages' to 'Examples'. 
 
 
 
@@ -26,7 +62,7 @@ Release date: Friday 16 December 2016
 
 ### Fixed
 
-* Floating footer fixed on example pages.
+* Fix floating footer on example pages.
 
 
 
@@ -53,7 +89,7 @@ Release date: Thursday 15 December 2016
 ### Changed
 
 * Update CONTRIBUTING-CHEATSHEET to include specific instructions about updating package.json and CHANGELOG.md before deployment, and tagging releases after deployment.
-* Added day names to CHANGELOG.md to match house style regarding dates.
+* Add day names to CHANGELOG.md to match house style regarding dates.
 
 
 
@@ -93,9 +129,9 @@ Release date: Tuesday 13 December 2016
 
 ### Changed
 
-* Updated footer pattern documentation.
+* Update footer pattern documentation.
 * Social media icons within the footer now use [Font Awesome](http://fontawesome.io/) instead of SVG images. 
-* Added new example with deprecated code for the SVG links.
+* Add new example with deprecated code for the SVG links.
 
 
 

--- a/src/examples/_data/prototype-text-banner.json
+++ b/src/examples/_data/prototype-text-banner.json
@@ -1,30 +1,30 @@
 {
     "university-home": {
       "style-type": "success",
-      "message": "Example University home page. <a href='../example-pages.html'>Back to example pages</a>."
+      "message": "Example University home page. <a href='../examples.html'>Back to example pages</a>."
     },
     "about": {
       "style-type": "success",
-      "message": "Example about page. <a href='../example-pages.html'>Back to example pages</a>."
+      "message": "Example about page. <a href='../examples.html'>Back to example pages</a>."
     },
     "content": {
       "style-type": "success",
-      "message": "Example content page. <a href='../example-pages.html'>Back to example pages</a>."
+      "message": "Example content page. <a href='../examples.html'>Back to example pages</a>."
     },
     "gallery": {
       "style-type": "success",
-      "message": "Example gallery. <a href='../example-pages.html'>Back to example pages</a>."
+      "message": "Example gallery. <a href='../examples.html'>Back to example pages</a>."
     },
     "web-application": {
       "style-type": "success",
-      "message": "Example web application. <a href='../example-pages.html'>Back to example pages</a>."
+      "message": "Example web application. <a href='../examples.html'>Back to example pages</a>."
     },
     "long-form": {
       "style-type": "success",
-      "message": "Example long form content page. <a href='../example-pages.html'>Back to example pages</a>."
+      "message": "Example long form content page. <a href='../examples.html'>Back to example pages</a>."
     },
     "html-elements": {
       "style-type": "success",
       "message": "Example HTML elements. <a href='../pattern-pages.html'>Back to pattern pages</a>."
-    }    
+    }
 }


### PR DESCRIPTION
Correct URL in text-banner on example pages to take users back to the examples homepage.
Update Changelog for v0.8.13 and v0.8.14, and fix a few typos in previous versions.