### PR TITLE
Merge (more-news) Change pager-alignment to pager

### DIFF
--- a/src/patterns/more-news/more-news.hbs
+++ b/src/patterns/more-news/more-news.hbs
@@ -15,7 +15,7 @@
             <hr>
             {{/each}}
             {{#if pagination}}
-                {{> pager-alignment}}
+                {{> pager}}
             {{/if}}
         </div>
     </div>


### PR DESCRIPTION
More-news was referring to page-alignment partial, but this had been changed to pager in a previous commit.