### PR TITLE
FIX (Form-elements) Fix datepicker mobile error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Release date: Wednesday 29 March 2017
 
 * Deprecated Glyphicons pattern.
 
+### Fixed
+
+* Fix datepicker on desktop.
+
 
 
 

--- a/src/patterns/form-elements/form-elements-options.json
+++ b/src/patterns/form-elements/form-elements-options.json
@@ -85,7 +85,7 @@
                     "column-size": "col-md-4",
                     "input": [
                         {
-                            "input-id": "datepicker-selectable",
+                            "input-id": "datepicker",
                             "label-text": "Pick a date",
                             "input-class": "form-control",
                             "type": "date"

--- a/src/patterns/form-elements/form-elements.js
+++ b/src/patterns/form-elements/form-elements.js
@@ -57,6 +57,7 @@ if ( $(".limit-counter").length ) {
 }
 
 if ( $(window).width() > 450 ) {
+    $('#datepicker').attr("type","text");
     $('#datepicker').datepicker({
         dateFormat: "DD, dd MM yy",
         changeMonth: true,


### PR DESCRIPTION
Needed to disable the native datepicker on desktop by changing the type to text, instead of date. Also fix the ID for the example.