### PR TITLE
MERGE (content) Apply max-width 100% to all content images

### DIFF
--- a/src/styles/screen.scss
+++ b/src/styles/screen.scss
@@ -106,8 +106,11 @@ GLOBAL CSS RULES
 
 .content {
     margin-top: 20px;
-}
 
+    img {
+      max-width: 100%;
+    }
+}
 
 /* Course patterns global rules
    --------------------------------------------------------------------------


### PR DESCRIPTION
All images within content items are not being re-sized correctly.  Need to update CSS to include max-width 100% to fix this.
